### PR TITLE
release翻译成发布或者公开比较合适。

### DIFF
--- a/Chapter-4/Chapter-4-Item-19-Design-and-document-for-inheritance-or-else-prohibit-it.md
+++ b/Chapter-4/Chapter-4-Item-19-Design-and-document-for-inheritance-or-else-prohibit-it.md
@@ -80,7 +80,7 @@ So how do you decide what protected members to expose when you design a class fo
 
 When you design for inheritance a class that is likely to achieve wide use, realize that you are committing forever to the self-use patterns that you document and to the implementation decisions implicit in its protected methods and fields. These commitments can make it difficult or impossible to improve the performance or functionality of the class in a subsequent release. Therefore,**you must test your class by writing subclasses before you release it.**
 
-当你为继承设计一个可能获得广泛使用的类时，请意识到你将永远致力于你所记录的自使用模式，以及在其受保护的方法和字段中隐含的实现决策。这些承诺会使在后续版本中改进类的性能或功能变得困难或不可能。因此，**你必须在释放类之前通过编写子类来测试类。**
+当你为继承设计一个可能获得广泛使用的类时，请意识到你将永远致力于你所记录的自使用模式，以及在其受保护的方法和字段中隐含的实现决策。这些承诺会使在后续版本中改进类的性能或功能变得困难或不可能。因此，**你必须在发布类之前通过编写子类来测试类。**
 
 Also, note that the special documentation required for inheritance clutters up normal documentation, which is designed for programmers who create instances of your class and invoke methods on them. As of this writing, there is little in the way of tools to separate ordinary API documentation from information of interest only to programmers implementing subclasses.
 


### PR DESCRIPTION
原文81行：“you must test your class by writing subclasses before you release it.”，译文中83行翻译成“你必须在释放类之前通过编写子类来测试类”。release class 如果翻译成释放类有些奇怪，感觉将release翻译成发布或者公开比较合适。

<!-- Please don't delete this template -->
<!-- PULL REQUEST TEMPLATE -->

**When resolving a issue, it's referenced in follow:** （当解决一个 issue 时，引用该 issue 的编号）

<!-- (e.g. `closes #xxx[,#xxx]`, where "xxx" is the issue number) -->

closes #

**What kind of change does this PR introduce? (check at least one.)** （该 PR 带来了什么样的改变，至少选择一个）

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix（错误修复）
- [x] Improvement（改进翻译质量）
- [ ] Other, please describe（其他）:

**The PR fulfills these requirements:** （该 PR 应该符合的要求）

- [ ] It's submitted to the `dev` branch, not the `master` branch.（该 PR 应该提交到 `dev` 分支，而不是 `master` 分支）

**Other information（其他信息）:**
