### PR TITLE
翻译勘误

### DIFF
--- a/Chapter-4/Chapter-4-Item-17-Minimize-mutability.md
+++ b/Chapter-4/Chapter-4-Item-17-Minimize-mutability.md
@@ -147,7 +147,7 @@ The package-private mutable companion class approach works fine if you can accur
 
 Now that you know how to make an immutable class and you understand the pros and cons of immutability, let’s discuss a few design alternatives. Recall that to guarantee immutability, a class must not permit itself to be subclassed. This can be done by making the class final, but there is another, more flexible alternative. Instead of making an immutable class final, you can make all of its constructors private or package-private and add public static factories in place of the public constructors (Item 1). To make this concrete, here’s how Complex would look if you took this approach:
 
-既然你已经知道了如何创建不可变类，并且了解了不可变性的优缺点，那么让我们来讨论一些设计方案。回想一下，为了保证不变性，类不允许自己被子类化。可以用 final 修饰以达到目的，但是还有另外一个更灵活的选择，你可以将其所有构造函数变为私有或包私有，并在公共构造函数的位置添加公共静态工厂（[Item-1](/Chapter-2/Chapter-2-Item-1-Consider-static-factory-methods-instead-of-constructors.md)）。
+既然你已经知道了如何创建不可变类，并且了解了不可变性的优缺点，那么让我们来讨论一些设计方案。回想一下，为了保证不变性，类不允许自己被子类化。可以用 final 修饰以达到目的，但是还有另外一个更灵活的选择，你可以将其所有构造函数变为私有或包私有，并使用公共静态工厂方法来代替公共的构造方法（[Item-1](/Chapter-2/Chapter-2-Item-1-Consider-static-factory-methods-instead-of-constructors.md)）。下面是Complex中采用这种方式来实现的例子。
 
 ```
 // Immutable class with static factories instead of constructors

--- a/Chapter-4/Chapter-4-Item-17-Minimize-mutability.md
+++ b/Chapter-4/Chapter-4-Item-17-Minimize-mutability.md
@@ -147,7 +147,7 @@ The package-private mutable companion class approach works fine if you can accur
 
 Now that you know how to make an immutable class and you understand the pros and cons of immutability, let’s discuss a few design alternatives. Recall that to guarantee immutability, a class must not permit itself to be subclassed. This can be done by making the class final, but there is another, more flexible alternative. Instead of making an immutable class final, you can make all of its constructors private or package-private and add public static factories in place of the public constructors (Item 1). To make this concrete, here’s how Complex would look if you took this approach:
 
-既然你已经知道了如何创建不可变类，并且了解了不可变性的优缺点，那么让我们来讨论一些设计方案。回想一下，为了保证不变性，类不允许自己被子类化。可以用 final 修饰以达到目的，但是还有另外一个更灵活的选择，你可以将其所有构造函数变为私有或包私有，并使用公共静态工厂方法来代替公共的构造方法（[Item-1](/Chapter-2/Chapter-2-Item-1-Consider-static-factory-methods-instead-of-constructors.md)）。下面是Complex中采用这种方式来实现的例子。
+既然你已经知道了如何创建不可变类，并且了解了不可变性的优缺点，那么让我们来讨论一些设计方案。回想一下，为了保证不变性，类不允许自己被子类化。可以用 final 修饰以达到目的，但是还有另外一个更灵活的选择，你可以将其所有构造函数变为私有或包私有，并使用公共静态工厂方法来代替公共的构造函数（[Item-1](/Chapter-2/Chapter-2-Item-1-Consider-static-factory-methods-instead-of-constructors.md)）。Complex 类采用这种方式修改后如下所示：
 
 ```
 // Immutable class with static factories instead of constructors


### PR DESCRIPTION
原文148行：“add public static factories in place of the public constructors ”
译文150行：“并在公共构造函数的位置添加公共静态工厂”
“in place of”应该翻译成“代替”，而不是在xx位置。还有后面的“To make this concrete, here’s how Complex would look if you took this approach”并没有翻译，可以翻译成“下面是Complex中采用这种方式来实现的例子。”

<!-- Please don't delete this template -->
<!-- PULL REQUEST TEMPLATE -->

**When resolving a issue, it's referenced in follow:** （当解决一个 issue 时，引用该 issue 的编号）

<!-- (e.g. `closes #xxx[,#xxx]`, where "xxx" is the issue number) -->

closes #

**What kind of change does this PR introduce? (check at least one.)** （该 PR 带来了什么样的改变，至少选择一个）

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix（错误修复）
- [x] Improvement（改进翻译质量）
- [ ] Other, please describe（其他）:

**The PR fulfills these requirements:** （该 PR 应该符合的要求）

- [ ] It's submitted to the `dev` branch, not the `master` branch.（该 PR 应该提交到 `dev` 分支，而不是 `master` 分支）

**Other information（其他信息）:**
