### PR TITLE
Improve the title translation of item 66

### DIFF
--- a/Chapter-9/Chapter-9-Item-65-Prefer-interfaces-to-reflection.md
+++ b/Chapter-9/Chapter-9-Item-65-Prefer-interfaces-to-reflection.md
@@ -103,4 +103,4 @@ In summary, reflection is a powerful facility that is required for certain sophi
 ---
 **[Back to contents of the chapter（返回章节目录）](/Chapter-9/Chapter-9-Introduction.md)**
 - **Previous Item（上一条目）：[Item 64: Refer to objects by their interfaces（通过接口引用对象）](/Chapter-9/Chapter-9-Item-64-Refer-to-objects-by-their-interfaces.md)**
-- **Next Item（下一条目）：[Item 66: Use native methods judiciously（明智地使用本地方法）](/Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md)**
+- **Next Item（下一条目）：[Item 66: Use native methods judiciously（谨慎地使用本地方法）](/Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md)**

--- a/Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md
+++ b/Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md
@@ -1,6 +1,6 @@
 ## Chapter 9. General Programming（通用程序设计）
 
-### Item 66: Use native methods judiciously（明智地使用本地方法）
+### Item 66: Use native methods judiciously（谨慎地使用本地方法）
 
 The Java Native Interface (JNI) allows Java programs to call native methods, which are methods written in native programming languages such as C or C++. Historically, native methods have had three main uses. They provide access to platform-specific facilities such as registries. They provide access to existing libraries of native code, including legacy libraries that provide access to legacy data. Finally, native methods are used to write performance-critical parts of applications in native languages for improved performance.
 
@@ -16,7 +16,7 @@ It is legitimate to use native methods to access platform-specific facilities, b
 
 A sad coda to this story is that BigInteger has changed little since then, with the exception of faster multiplication for large numbers in Java 8. In that time, work continued apace on native libraries, notably GNU Multiple Precision arithmetic library (GMP). Java programmers in need of truly high-performance multiprecision arithmetic are now justified in using GMP via native methods [Blum14].
 
-这个故事的一个可悲的结尾是，除了在 Java 8 中对大数进行更快的乘法运算之外，BigInteger 此后几乎没有发生什么变化。在此期间，对本地库的工作继续快速进行，尤其是 GNU 多精度算术库（GMP）。需要真正高性能多精度算法的 Java 程序员现在可以通过本地方法使用 GMP [Blum14]。
+这个故事的一个可悲的结尾是，除了在 Java 8 中对大整数进行更快的乘法运算之外，BigInteger 此后几乎没有发生什么变化。在此期间，本地库的工作还在持续地快速发展，尤其是 GNU 多精度算术库（GMP）。对于需要真正高性能多精度算法的 Java 程序员，现在通过本地方法使用 GMP 是无可厚非的 [Blum14]。
 
 The use of native methods has serious disadvantages. Because native languages are not safe (Item 50), applications using native methods are no longer immune to memory corruption errors. Because native languages are more platform-dependent than Java, programs using native methods are less portable. They are also harder to debug. If you aren’t careful, native methods can decrease performance because the garbage collector can’t automate, or even track, native memory usage (Item 8), and there is a cost associated with going into and out of native code. Finally, native methods require “glue code” that is difficult to read and tedious to write.
 

--- a/Chapter-9/Chapter-9-Item-67-Optimize-judiciously.md
+++ b/Chapter-9/Chapter-9-Item-67-Optimize-judiciously.md
@@ -92,5 +92,5 @@ To summarize, do not strive to write fast programs—strive to write good ones; 
 
 ---
 **[Back to contents of the chapter（返回章节目录）](/Chapter-9/Chapter-9-Introduction.md)**
-- **Previous Item（上一条目）：[Item 66: Use native methods judiciously（明智地使用本地方法）](/Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md)**
+- **Previous Item（上一条目）：[Item 66: Use native methods judiciously（谨慎地使用本地方法）](/Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md)**
 - **Next Item（下一条目）：[Item 68: Adhere to generally accepted naming conventions（遵守被广泛认可的命名约定）](/Chapter-9/Chapter-9-Item-68-Adhere-to-generally-accepted-naming-conventions.md)**

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Effective Java（第 3 版）各章节的中英文学习参考，希望对 Java 
     - [Item 63: Beware the performance of string concatenation（当心字符串连接引起的性能问题）](Chapter-9/Chapter-9-Item-63-Beware-the-performance-of-string-concatenation.md)
     - [Item 64: Refer to objects by their interfaces（通过接口引用对象）](Chapter-9/Chapter-9-Item-64-Refer-to-objects-by-their-interfaces.md)
     - [Item 65: Prefer interfaces to reflection（接口优于反射）](Chapter-9/Chapter-9-Item-65-Prefer-interfaces-to-reflection.md)
-    - [Item 66: Use native methods judiciously（明智地使用本地方法）](Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md)
+    - [Item 66: Use native methods judiciously（谨慎地使用本地方法）](Chapter-9/Chapter-9-Item-66-Use-native-methods-judiciously.md)
     - [Item 67: Optimize judiciously（明智地进行优化）](Chapter-9/Chapter-9-Item-67-Optimize-judiciously.md)
     - [Item 68: Adhere to generally accepted naming conventions（遵守被广泛认可的命名约定）](Chapter-9/Chapter-9-Item-68-Adhere-to-generally-accepted-naming-conventions.md)
 - **Chapter 10. Exceptions（异常）**


### PR DESCRIPTION
<!-- Please don't delete this template -->
<!-- PULL REQUEST TEMPLATE -->

第 66 条中的内容，是不建议 Java 程序员调用本地方法，文章中有如下描述：

- It is rarely advisable to use native methods for improved performance.
- The use of native methods has serious disadvantages.
- In summary, think twice before using native methods.
- It is rare that you need to use them for improved performance.

感觉将标题的 `judiciously` 翻译成“谨慎地”，比“明智地”更贴合本条的内容。


**When resolving a issue, it's referenced in follow:** （当解决一个 issue 时，引用该 issue 的编号）

<!-- (e.g. `closes #xxx[,#xxx]`, where "xxx" is the issue number) -->

closes #

**What kind of change does this PR introduce? (check at least one.)** （该 PR 带来了什么样的改变，至少选择一个）

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix（错误修复）
- [x] Improvement（改进翻译质量）
- [ ] Other, please describe（其他）:

**The PR fulfills these requirements:** （该 PR 应该符合的要求）

- [x] It's submitted to the `dev` branch, not the `master` branch.（该 PR 应该提交到 `dev` 分支，而不是 `master` 分支）

**Other information（其他信息）:**
